### PR TITLE
Added the ability to do a raw put request with headers

### DIFF
--- a/lib/qumulo/rest/http.rb
+++ b/lib/qumulo/rest/http.rb
@@ -71,7 +71,7 @@ module Qumulo::Rest
     # JSON::ParserError if successful response does not contain valid JSON
     #
     def http_execute(request)
-      request.content_type = "application/json"
+      request.content_type ||= "application/json"
       request["Authorization"] = @bearer_token if @bearer_token
       http = Net::HTTP.new(@host, @port)
       http.use_ssl = true
@@ -142,6 +142,24 @@ module Qumulo::Rest
         put["if-match"] = etag
       end
       http_execute(put)
+    end
+
+    # === Description
+    # Perform PUT request and allow the body and headers to be specified.
+    #
+    # === Parameters
+    # path:: URI path, including query string parameters
+    # attrs:: Hash object containing key-value pairs representing resource
+    # options:: (optional) Allows options such as :headers to be passed in
+    #
+    # === Returns
+    # result Hash object
+    #
+    def put_raw(path, body = nil, options = { })
+      headers = options[:headers]
+      post = Net::HTTP::Put.new(path, headers)
+      post.body = body
+      http_execute(post)
     end
 
     # === Description


### PR DESCRIPTION
This allow for put_raw to be used on requests such as writing data to a file.

Example:

```
module Qumulo::Rest::V1
  class FilesData < ::Qumulo::Rest::Base
    uri_spec '/v1/files/:ref/data'
    field :ref, String
    field :body, String

    def put(request_opts = {})
      store_result(
          http(request_opts).
              put_raw(resolved_path,
                       @attrs['body'],
                       { :headers => { 'Content-Type' => 'application/octet-stream' } }
              )
      )
    end

  end
end
```
